### PR TITLE
constrain public search to published resources

### DIFF
--- a/app/api/search/public_services.py
+++ b/app/api/search/public_services.py
@@ -9,8 +9,15 @@ index_handler = IndexHandler.IndexHandler()
 ELASTIC_INDEX_PREFIX = os.environ.get('ELASTIC_INDEX_PREFIX', '')
 
 
+def _published_only(body):
+    body = dict(body or {})
+    body['status'] = 'published'
+    return body
+
+
 def get_resources_by_filters(body):
     try:
+        body = _published_only(body)
         capabilities, status = get_system_settings()
         capabilities = capabilities['capabilities']
         searchSource = body.get('searchSource', 'index')
@@ -33,6 +40,7 @@ def get_resources_by_filters(body):
 
 def get_rss_feed(body, base_url, link_template, feed_title, feed_description):
     try:
+        body = _published_only(body)
         capabilities, status = get_system_settings()
         capabilities = capabilities['capabilities']
         searchSource = body.get('searchSource', 'index')

--- a/app/utils/functions.py
+++ b/app/utils/functions.py
@@ -25,10 +25,6 @@ except (TypeError, ValueError):
 mongodb = DatabaseHandler.DatabaseHandler()
 cacheHandler = CacheHandler.CacheHandler()
 
-# Page-rendering directories and image derivative suffixes, keyed by the name a
-# request may ask for. These are allowlists: the request's `size` selects a key,
-# it never becomes part of a path. Any value not listed here is refused before a
-# path is built.
 PAGE_DIRECTORIES = {'small': 'small', 'big': 'big'}
 GALLERY_SUFFIXES = {
     'small': '_small.jpg',


### PR DESCRIPTION
The public search and RSS endpoints now fix the publication state rather than accepting it from the request body.